### PR TITLE
Support optional screen titles

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ Revision history for Pod-PseudoPod-LaTeX
     - support =for latex (Alberto Simões)
     - render L<> as \url (Alberto Simões)
     - make ligatures removal optional (Alberto Simões)
+    - support optional titles for 'screen' (Alberto Simões)
 
 1.101600  Wed Jun 9 13:48:24 2010
     - made bin/ppod2latex installable (Jerome Quelin, RT #58269)

--- a/lib/Pod/PseudoPod/LaTeX.pm
+++ b/lib/Pod/PseudoPod/LaTeX.pm
@@ -341,8 +341,8 @@ sub start_Verbatim
     my $verb_options = "commandchars=\\\\\\{\\}";
     eval {
         if ($self->{curr_open}[-1][-1]{target} eq 'screen') {
-            $verb_options .= ',frame=single,label='
-                             . $self->{labels}{screen};
+            my $label = $self->{curr_open}[-1][-1]{title} || $self->{labels}{screen};
+            $verb_options .= ",frame=single,label=$label";
         }
     };
 


### PR DESCRIPTION
This is a simple patch to support titles on screen environments.

By default "Program output" is used. But if the user makes the title clear, use it:

=begin screen Example of CPAN usage

   ...

=end screen

cheers
