### PR TITLE
Added missing package on documentation

### DIFF
--- a/lib/Pod/PseudoPod/LaTeX.pm
+++ b/lib/Pod/PseudoPod/LaTeX.pm
@@ -675,8 +675,9 @@ Perhaps a little code snippet.
 The generated LaTeX code needs some packages to be loaded to work correctly.
 Currently it needs
 
-    \usepackage{fancyvrb}
-    \usepackage{url}
+    \usepackage{fancyvrb}  % for Screen and Verbatim environments
+    \usepackage{url}       % for L<> URLs
+    \usepackage{titleref}  % for A<> generated code
 
 The standard font in LaTeX (Computer Modern) does not support bold and italic
 variants of its monospace font, an alternative is


### PR DESCRIPTION
`\usepackage{titleref}` was missing from the documentation. Took the chance to add some more info to the package listing.
