### PR TITLE
Pr/verbatim environments

### DIFF
--- a/lib/Pod/PseudoPod/LaTeX.pm
+++ b/lib/Pod/PseudoPod/LaTeX.pm
@@ -22,7 +22,7 @@ sub new
     );
 
     # These do not. Content is not touched.
-    $self->accept_taget('latex');
+    $self->accept_target('latex');
 
     $self->{scratch} ||= '';
     $self->{stack}     = [];


### PR DESCRIPTION
I discovered that we can define =begin and =for environments in two different ways: accept_target_as_text and accept_target. The first means that its contents should be still parsed. The second says it should not.

This is useful for cases when we do not want to parse environments contents. Already rewrote my latex patch from a few days ago to use this feature, and changed the encode_text function to honour this information.

This way I can write in my own build system:

```
$parser->accept_target('Perl');
$parser->emit_environments('Perl' => 'lstlisting');
```

and use the listings latex package to render the Perl code. Sweet :)

@chromatic, @moritz suggested I should ask for commit access, so he have less work. If you are happy with it, I would be happy too (and I'll try not to break things :) )

Cheers
