### PR TITLE
Fix "captions_below" package option

### DIFF
--- a/lib/Pod/PseudoPod/LaTeX.pm
+++ b/lib/Pod/PseudoPod/LaTeX.pm
@@ -16,7 +16,7 @@ sub new
     my $self             = $class->SUPER::new(%args);
 
     $self->{keep_ligatures}  = exists($args{keep_ligatures})  ? $args{keep_ligatures}  : 0;
-    $self->{captions_bellow} = exists($args{captions_bellow}) ? $args{captions_bellow} : 0;
+    $self->{captions_below} = exists($args{captions_below}) ? $args{captions_below} : 0;
 
     # These have their contents parsed
     $self->accept_targets_as_text(
@@ -417,7 +417,7 @@ sub start_figure
 
     $self->{_dangling_title} = undef; # just in case; Do not think it is worth a stack.
     if ( $flags->{title} ) {
-        if ($self->{captions_bellow}) {
+        if ($self->{captions_below}) {
             $self->{_dangling_title} = $flags->{title};
         }
         else {
@@ -436,7 +436,7 @@ sub end_figure
     my $self = shift;
     $self->{scratch} .= "\\end{center}\n";
 
-    if ($self->{captions_bellow} && $self->{_dangling_title})
+    if ($self->{captions_below} && $self->{_dangling_title})
     {
         my $title = $self->encode_text( $self->{_dangling_title} );
         $title    =~ s/^graphic\s*//;
@@ -459,7 +459,7 @@ sub start_table
     $self->{_dangling_title} = undef; # just in case; Do not think it is worth a stack.
     if ( $flags->{title} )
     {
-        if ($self->{captions_bellow}) {
+        if ($self->{captions_below}) {
             $self->{_dangling_title} = $flags->{title};
         }
         else {
@@ -500,7 +500,7 @@ sub end_table
                      .  "\\end{center}\n";
 
 
-    if ($self->{captions_bellow} && $self->{_dangling_title})
+    if ($self->{captions_below} && $self->{_dangling_title})
     {
         my $title = $self->encode_text( $self->{_dangling_title} );
         $title    =~ s/^graphic\s*//;
@@ -764,10 +764,10 @@ them with ligatures, use:
 
   my $parser = Pod::PseudoPod::LaTeX->new( keep_ligatures => 1 );
 
-=item C<captions_bellow>
+=item C<captions_below>
 
 Set this flag to a true value if you prefer that figure and table
-captions are placed bellow the object and not above (the default).
+captions are placed below the object and not above (the default).
 
 =back
 

--- a/t/options.t
+++ b/t/options.t
@@ -1,0 +1,29 @@
+#! perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+
+use_ok( 'Pod::PseudoPod::LaTeX' ) or exit;
+
+subtest "default options" => sub {
+    plan tests => 2;
+
+    my $parser = Pod::PseudoPod::LaTeX->new();
+    ok !$parser->{'keep_ligatures'}, "default keep_ligatures value";
+    ok !$parser->{'captions_below'}, "default captions_below value";
+};
+
+subtest "set options explicitly" => sub {
+    plan tests => 2;
+
+    my $parser = Pod::PseudoPod::LaTeX->new(
+        keep_ligatures => 1,
+        captions_below => 1,
+    );
+    ok $parser->{'keep_ligatures'}, "keep_ligatures turned on";
+    ok $parser->{'captions_below'}, "captions_below turned on";
+};
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
The "captions_below" package option was incorrectly spelled "captions_bellow"; this PR fixes the spelling error in the code and documentation, and adds a very basic test of the package options.