### PR TITLE
Add initial Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: perl
+
+perl:
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - cpanm Dist::Zilla
+    - dzil authordeps --missing | cpanm -n
+    - dzil listdeps --missing | cpanm -n
+
+script:
+    - dzil test --author --release


### PR DESCRIPTION
The PR adds the configuration file for the [Travis continuous integration](https://travis-ci.org) service and tests Perls 5.10 to 5.22.