### PR TITLE
Add package options to ppod2latex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 !.gitignore
 Pod-PseudoPod-LaTeX-*
 .build/*
+build

--- a/bin/ppod2latex
+++ b/bin/ppod2latex
@@ -5,6 +5,7 @@ use warnings;
 
 use File::Basename;
 use File::Spec::Functions;
+use File::Path qw(mkpath);
 use Pod::PseudoPod::LaTeX;
 
 die "$0 <files to pdfify>\n" unless @ARGV;
@@ -16,6 +17,7 @@ for my $file (@ARGV)
         'build',
         (fileparse( $file, qr/\.pod$/ ))[0] . '.tex'
     );
+    mkpath( 'build' ) unless -e 'build';
     open( my $fh, '>', $outfile ) or die "Can't write to '$outfile': $!\n";
 
     my $parser    = Pod::PseudoPod::LaTeX->new();

--- a/bin/ppod2latex
+++ b/bin/ppod2latex
@@ -37,3 +37,39 @@ for my $file (@ARGV)
 
     $parser->parse_file( $file );
 }
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+ppod2latex - convert PseudoPod to LaTeX
+
+=head1 SYNOPSIS
+
+    ppod2latex [--keep_ligatures] [--captions_below] <file-list>
+
+=head1 DESCRIPTION
+
+Convert a file (or list of files) written in PseudoPod into LaTeX for later
+processing to e.g. PDF via C<pdflatex>.
+
+The output LaTeX text requires a LaTeX preamble and needs to be wrapped
+within a C<document> environment.
+
+=head1 OPTIONS
+
+=over 4
+
+=item keep_ligatures
+
+Retain ligatures in LaTeX output text.  Thus the character pairs fi, fl, and
+ft will be joined when LaTeX produces its output.
+
+=item captions_below
+
+Put figure and table captions below the object as opposed to above, which is
+the default.
+
+=back

--- a/bin/ppod2latex
+++ b/bin/ppod2latex
@@ -15,7 +15,10 @@ GetOptions(
     "captions_below" => \my $captions_below,
 ) or pod2usage(2);
 
-die "$0 <files to pdfify>\n" unless @ARGV;
+pod2usage(
+    -msg     => "Please enter a file or list of files",
+    -exitval => 2,
+) unless @ARGV;
 
 for my $file (@ARGV)
 {

--- a/bin/ppod2latex
+++ b/bin/ppod2latex
@@ -7,6 +7,13 @@ use File::Basename;
 use File::Spec::Functions;
 use File::Path qw(mkpath);
 use Pod::PseudoPod::LaTeX;
+use Getopt::Long;
+use Pod::Usage;
+
+GetOptions(
+    "keep_ligatures" => \my $keep_ligatures,
+    "captions_below" => \my $captions_below,
+) or pod2usage(2);
 
 die "$0 <files to pdfify>\n" unless @ARGV;
 
@@ -20,7 +27,10 @@ for my $file (@ARGV)
     mkpath( 'build' ) unless -e 'build';
     open( my $fh, '>', $outfile ) or die "Can't write to '$outfile': $!\n";
 
-    my $parser    = Pod::PseudoPod::LaTeX->new();
+    my $parser    = Pod::PseudoPod::LaTeX->new(
+	keep_ligatures => $keep_ligatures,
+	captions_below => $captions_below,
+    );
     $parser->output_fh( $fh );
 
     warn "$file -> $outfile\n";


### PR DESCRIPTION
The `Pod::PseudoPod::LaTeX` package accepts the `keep_ligatures` and `captions_below` options; this PR allows the user to set these options via command line options to `ppod2latex`.  It relies upon PR #13 (fix `captions_below` package option) being accepted in order that everything works correctly.  The command line tool also has had POD added to it in order to give more help and feedback to the user.  If there are any questions or comments concerning this PR, please just let me know and I can fix anything as required and resubmit as necessary.