### PR TITLE
Remove Perls 5.10 and 5.12 from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ perl:
     - "5.18"
     - "5.16"
     - "5.14"
-    - "5.12"
-    - "5.10"
 
 install:
     - cpanm Dist::Zilla


### PR DESCRIPTION
... because Dist::Zilla requires 5.14 as minimum Perl version.