### PR TITLE
Fix cedilla and plusmn translations

### DIFF
--- a/lib/Pod/PseudoPod/LaTeX.pm
+++ b/lib/Pod/PseudoPod/LaTeX.pm
@@ -178,10 +178,10 @@ my %characters = (
     acute   => sub { qq|\\'| . shift },
     grave   => sub { qq|\\`| . shift },
     uml     => sub { qq|\\"| . shift },
-    cedilla => sub { '\c' },              # ccedilla
+    cedilla => sub { '\c{c}' },           # ccedilla
     opy     => sub { '\copyright' },      # copy
     dash    => sub { '---' },             # mdash
-    lusmn   => sub { '\pm' },             # plusmn
+    lusmn   => sub { '$\pm$' },           # plusmn
     mp      => sub { '\&' },              # amp
 );
 

--- a/t/translations.t
+++ b/t/translations.t
@@ -30,14 +30,14 @@ like( $text, qr/na\\"ive/,
 like( $text, qr/attach\\`e/,
 	'grave diacritic should translate to single backquote escape' );
 
-like( $text, qr/Fran\\caise/, 'cedilla should translate to \c' );
+like( $text, qr/Fran\\c{c}aise/, 'cedilla should translate to \c{c}' );
 
 like( $text, qr/\\copyright caper/, 'copyright symbol should get escaped' );
 
 like( $text, qr/ligatures---and/,
 	'double hyphen dash should become unspacey long dash' );
 
-like( $text, qr/\\pm some constant/, 'plusmn should get an escape too' );
+like( $text, qr/\$\\pm\$ some constant/, 'plusmn should get an escape too' );
 
 like( $text, qr/\\textbf{very} important/,
 	'bold text needs a formatting directive' );


### PR DESCRIPTION
The cedilla in LaTeX is actually `\c{c}` (see, e.g.
https://en.wikibooks.org/wiki/LaTeX/Special_Characters#Escaped_codes) and
the `\pm` command needs to be wrapped in dollar signs if it's used outside
of math mode (i.e. outside an equation, $$, or similar environment).  This
commit fixes the issue so that if the test file (`t/test_file.pod`) is run
through `ppod2latex` then it produces LaTeX which can be processed properly
by `latex` or `pdflatex`.