### PR TITLE
Improve handling of plusmn

### DIFF
--- a/lib/Pod/PseudoPod/LaTeX.pm
+++ b/lib/Pod/PseudoPod/LaTeX.pm
@@ -194,11 +194,11 @@ my %characters = (
     acute   => sub { qq|\\'| . shift },
     grave   => sub { qq|\\`| . shift },
     uml     => sub { qq|\\"| . shift },
-    cedilla => sub { '\c{c}' },           # ccedilla
-    opy     => sub { '\copyright' },      # copy
-    dash    => sub { '---' },             # mdash
-    lusmn   => sub { '$\pm$' },           # plusmn
-    mp      => sub { '\&' },              # amp
+    cedilla => sub { '\c{c}' },              # ccedilla
+    opy     => sub { '\copyright' },         # copy
+    dash    => sub { '---' },                # mdash
+    lusmn   => sub { '\ensuremath{\pm}' },   # plusmn
+    mp      => sub { '\&' },                 # amp
 );
 
 sub end_E

--- a/t/translations.t
+++ b/t/translations.t
@@ -37,7 +37,7 @@ like( $text, qr/\\copyright caper/, 'copyright symbol should get escaped' );
 like( $text, qr/ligatures---and/,
 	'double hyphen dash should become unspacey long dash' );
 
-like( $text, qr/\$\\pm\$ some constant/, 'plusmn should get an escape too' );
+like( $text, qr/\\ensuremath{\\pm} some constant/, 'plusmn should get an escape too' );
 
 like( $text, qr/\\textbf{very} important/,
 	'bold text needs a formatting directive' );


### PR DESCRIPTION
Using `\ensuremath` is robuster than simply wrapping `\pm` in dollar signs.
This commit updates how plusmn is handled.

Kudos to @moritz++ for pointing out the improvement.